### PR TITLE
fixed bugs

### DIFF
--- a/src/nc_log.cpp
+++ b/src/nc_log.cpp
@@ -85,14 +85,14 @@ namespace ncserver
 				message = (char*)alloca(bufferSize + headerSize);
 				memcpy(message, header, headerSize);
 				int requiredSize = vsnprintf(message + headerSize, bufferSize, format, args);
-				if (requiredSize < 0)
+				if (requiredSize < 0 || requiredSize >= 64 * 1024)
 				{
 					failed = true;
 					break;	// error
 				}
 				else if (requiredSize < bufferSize)
 					break;	// done
-				else
+				else 
 				{
 					// buffer insufficient
 					bufferSize = 64 * 1024;

--- a/test/nc_logger_unittest.cpp
+++ b/test/nc_logger_unittest.cpp
@@ -5,10 +5,34 @@
 
 using namespace ncserver;
 
-TEST(NcLog, basic)
+class NcLogTest : public ::testing::Test
 {
-	NcLog::instance().registerUpdateLogLevelSignal();
-	NcLog::instance().init("echo", LogLevel_info);
-	
-	ASYNC_LOG_ALERT("Hello %s", "world");
+public:
+
+	static void SetUpTestCase()
+	{
+		NcLog::instance().registerUpdateLogLevelSignal();
+		NcLog::instance().init("echo", LogLevel_info);
+	}
+};
+
+TEST_F(NcLogTest, basic)
+{
+	ASYNC_LOG_INFO("basic log %s", "world");
+}
+
+TEST_F(NcLogTest, max)
+{
+	char* text = new char[8 * 1024];
+	memset(text, 'a', 8 * 1024 - 1);
+	text[8 * 1024 - 1] = '\0';
+	ASYNC_LOG_CRIT("max log %s", text);
+}
+
+TEST_F(NcLogTest, superMax)
+{
+	char* text = new char[64 * 1024];
+	memset(text, 'a', 64 * 1024 - 1);
+	text[64 * 1024 - 1] = '\0';
+	ASYNC_LOG_EMERG("superMax log %s", text);
 }


### PR DESCRIPTION
修复requiredSize >= 64 * 1024 时，死循环问题
备注：
vsnprintf 在win下超出范围会返回-1，在win下alloca永不会生效，需要确定一下是否需要改动？
